### PR TITLE
유저 프로필 수정 매커니즘 변경

### DIFF
--- a/src/main/kotlin/team/waggly/backend/controller/UserController.kt
+++ b/src/main/kotlin/team/waggly/backend/controller/UserController.kt
@@ -55,13 +55,22 @@ class UserController(
         return ResponseDto(certificationService.certificationEmail(certificationRequestDto),"이메일 인증이 완료되었습니다.", 200)
     }
 
-    @PutMapping("/user/profile")
-    fun updateUserProfile(
+    @PutMapping("/user/profile/nickname")
+    fun updateUserProfileNickname(
         @AuthenticationPrincipal userDetailsImpl: UserDetailsImpl,
         @RequestBody updateUserProfileRequestDto: UpdateUserProfileRequestDto,
     ): ResponseDto<UpdateUserProfileDto> {
         val user = userDetailsImpl.user
         return ResponseDto(userService.updateUserProfile(user, updateUserProfileRequestDto))
+    }
+
+    @PutMapping("/user/profile/img")
+    fun updateUserProfileImg(
+        @AuthenticationPrincipal userDetailsImpl: UserDetailsImpl,
+        @ModelAttribute updateUserProfileImgRequestDto: UpdateUserProfileImgRequestDto,
+    ): ResponseDto<UpdateUserProfileImgDto> {
+        val user = userDetailsImpl.user
+        return ResponseDto(userService.updateUserProfileImg(user, updateUserProfileImgRequestDto))
     }
 
     @PutMapping("/user/introduction")

--- a/src/main/kotlin/team/waggly/backend/dto/myPageDto/UpdateUserProfileDto.kt
+++ b/src/main/kotlin/team/waggly/backend/dto/myPageDto/UpdateUserProfileDto.kt
@@ -4,3 +4,7 @@ class UpdateUserProfileDto(
         val profileImg: String,
         val nickname: String
 )
+
+class UpdateUserProfileImgDto(
+        val profileImg: String,
+)

--- a/src/main/kotlin/team/waggly/backend/dto/myPageDto/UpdateUserProfileRequestDto.kt
+++ b/src/main/kotlin/team/waggly/backend/dto/myPageDto/UpdateUserProfileRequestDto.kt
@@ -6,3 +6,7 @@ class UpdateUserProfileRequestDto(
         val nickname: String,
         val profileImg: MultipartFile
 )
+
+class UpdateUserProfileImgRequestDto(
+        val profileImg: MultipartFile
+)

--- a/src/main/kotlin/team/waggly/backend/service/UserService.kt
+++ b/src/main/kotlin/team/waggly/backend/service/UserService.kt
@@ -30,6 +30,18 @@ class UserService(
     }
 
     @Transactional
+    fun updateUserProfileImg(user: User, updateUserProfileImgRequestDto: UpdateUserProfileImgRequestDto): UpdateUserProfileImgDto {
+        val updateUser = userRepository.findByIdOrNull(user.id!!)
+            ?: throw java.lang.IllegalArgumentException("해당 유저가 존재하지 않습니다.")
+        print(updateUserProfileImgRequestDto.profileImg)
+        updateUser.profileImgUrl = s3Uploader.upload(updateUserProfileImgRequestDto.profileImg)
+
+        return UpdateUserProfileImgDto(
+            updateUser.profileImgUrl,
+        )
+    }
+
+    @Transactional
     fun updateUserIntroduction(user: User, updateUserIntroductionRequestDto: UpdateUserIntroductionRequestDto): UpdateUserIntroductionDto {
         val updateUser = userRepository.findByIdOrNull(user.id!!)
                 ?: throw java.lang.IllegalArgumentException("해당 유저가 존재하지 않습니다.")


### PR DESCRIPTION
* 프로필 변경 매커니즘을 변경
동시에 프로필이미지와 닉네임을 변경 -> 따로 변경가능하도록 API 변경

why? 동시에 같이하게 된다면 프론트쪽에서 생각해야될게 너무 많기 떄문입니다.
-> 자세한건 수요일 회의때 물어봐주세요.