### PR TITLE
[feat] : 게시물 수정 - 게시물 이미지 삭제에서 삭제 시간 갱신으로 변경

### DIFF
--- a/src/main/kotlin/team/waggly/backend/repository/PostImageRepository.kt
+++ b/src/main/kotlin/team/waggly/backend/repository/PostImageRepository.kt
@@ -10,5 +10,6 @@ interface PostImageRepository : JpaRepository<PostImage, Long> {
     fun findAllByPostId(postId: Long): List<PostImage>
     fun countByPostId(postId: Long): Int
     fun findByImageUrlAndDeletedAtNull(imageUrl: String): PostImage?
+    fun findByImageUrl(imageUrl: String) : PostImage?
     fun findAllByPostIdAndDeletedAtNull(postId: Long): List<PostImage>?
 }

--- a/src/main/kotlin/team/waggly/backend/repository/PostRepository.kt
+++ b/src/main/kotlin/team/waggly/backend/repository/PostRepository.kt
@@ -24,4 +24,6 @@ interface PostRepository: JpaRepository<Post, Long> {
     fun findByIdAndActiveStatus(id: Long, activeStatus: ActiveStatusType): Post?
 
     fun findFirstByCollegeAndActiveStatusOrderByIdDesc(college: CollegeType, activeStatus: ActiveStatusType): Post?
+
+
 }

--- a/src/main/kotlin/team/waggly/backend/service/PostService.kt
+++ b/src/main/kotlin/team/waggly/backend/service/PostService.kt
@@ -214,8 +214,10 @@ class PostService(
                 val targetImage = postImageRepository.findByImageUrlAndDeletedAtNull(target)
                         ?: throw NotFoundException()
                 println(dir + targetImage.uploadName)
-                s3Uploader.delete(targetImage.uploadName)
-                postImageRepository.delete(targetImage)
+                println("asdasdasd");
+//                s3Uploader.delete(targetImage.uploadName)
+                val postImage = postImageRepository.findByImageUrl(targetImage.uploadName)
+                postImage?.deletedAt = LocalDateTime.now();
             }
         }
 


### PR DESCRIPTION
S3 삭제 권한 부여전 이미지 로직 수정
- 이미지를 삭제하는 것이 아니라 deleteAt 삭제한 시간으로 갱신
- 수정한 데이터를 보내줄 때 이미지중에서 deleteAt이 null인 값으로 이미지 전송