### PR TITLE
댓글 수 불러오는 쿼리 수정(active status추가)

### DIFF
--- a/src/main/kotlin/team/waggly/backend/repository/CommentRepository.kt
+++ b/src/main/kotlin/team/waggly/backend/repository/CommentRepository.kt
@@ -13,7 +13,7 @@ interface CommentRepository : JpaRepository<Comment, Long> {
     fun findByUserAndActiveStatusOrderByCreatedAtDesc(user: User, activeStatus: ActiveStatusType): List<Comment>
 
     // 게시글의 댓글 수
-    fun countByPostId(postId: Long): Int
+    fun countByPostIdAndActiveStatus(postId: Long, activeStatus: ActiveStatusType): Int
 
     fun findByPostAndActiveStatusAndParentCommentNullOrderByCreatedAtAsc(post: Post, activeStatus: ActiveStatusType): List<Comment>
 

--- a/src/main/kotlin/team/waggly/backend/service/HomeService.kt
+++ b/src/main/kotlin/team/waggly/backend/service/HomeService.kt
@@ -56,7 +56,7 @@ class HomeService(
 
         postDto.postImageCnt = postImageRepository.countByPostId(post.id!!)
         postDto.postLikeCnt = postLikeRepository.countByPostIdAndStatus(post.id, ActiveStatusType.ACTIVE)
-        postDto.postCommentCnt = commentRepository.countByPostId(post.id)
+        postDto.postCommentCnt = commentRepository.countByPostIdAndActiveStatus(post.id, ActiveStatusType.ACTIVE)
         postDto.isLikedByMe =
             if (userId != null) postLikeRepository.existsByPostIdAndUserIdAndStatus(
                 post.id,

--- a/src/main/kotlin/team/waggly/backend/service/MyPageService.kt
+++ b/src/main/kotlin/team/waggly/backend/service/MyPageService.kt
@@ -32,7 +32,7 @@ class MyPageService (
 
                 myPostsDetailDto.postImageCnt = postImageRepository.countByPostId(post.id!!)
                 myPostsDetailDto.postLikeCnt = postLikeRepository.countByPostIdAndStatus(post.id, ActiveStatusType.ACTIVE)
-                myPostsDetailDto.postCommentCnt = commentRepository.countByPostId(post.id)
+                myPostsDetailDto.postCommentCnt = commentRepository.countByPostIdAndActiveStatus(post.id, ActiveStatusType.ACTIVE)
                 myPostsDetailDto.isLikedByMe = postLikeRepository.existsByPostIdAndUserIdAndStatus(post.id, user.id!!, ActiveStatusType.ACTIVE)
 
                 postsDto.add(myPostsDetailDto)

--- a/src/main/kotlin/team/waggly/backend/service/PostService.kt
+++ b/src/main/kotlin/team/waggly/backend/service/PostService.kt
@@ -162,7 +162,7 @@ class PostService(
             }
         }
         postDetailDto.postLikeCnt = postLikeRepository.countByPostIdAndStatus(post.id, ActiveStatusType.ACTIVE)
-        postDetailDto.postCommentCnt = commentRepository.countByPostId(post.id)
+        postDetailDto.postCommentCnt = commentRepository.countByPostIdAndActiveStatus(post.id, ActiveStatusType.ACTIVE)
         postDetailDto.isLikedByMe = postLikeRepository.existsByPostIdAndUserIdAndStatus(post.id, userId, ActiveStatusType.ACTIVE)
         println(postLikeRepository.existsByPostIdAndUserIdAndStatus(post.id, userId, ActiveStatusType.ACTIVE))
 
@@ -234,7 +234,7 @@ class PostService(
         }
 
         postDetailDto.postLikeCnt = postLikeRepository.countByPostIdAndStatus(updatedPost.id, ActiveStatusType.ACTIVE)
-        postDetailDto.postCommentCnt = commentRepository.countByPostId(updatedPost.id)
+        postDetailDto.postCommentCnt = commentRepository.countByPostIdAndActiveStatus(updatedPost.id, ActiveStatusType.ACTIVE)
         postDetailDto.isLikedByMe = postLikeRepository.existsByPostIdAndUserIdAndStatus(post.id!!, user.id!!, ActiveStatusType.ACTIVE)
 
         return postDetailDto
@@ -288,7 +288,7 @@ class PostService(
     private fun updatePostDto(postDto: PostDto, userId: Long): PostDto {
         postDto.postImageCnt = postImageRepository.countByPostId(postDto.postId!!)
         postDto.postLikeCnt = postLikeRepository.countByPostIdAndStatus(postDto.postId, ActiveStatusType.ACTIVE)
-        postDto.postCommentCnt = commentRepository.countByPostId(postDto.postId)
+        postDto.postCommentCnt = commentRepository.countByPostIdAndActiveStatus(postDto.postId, ActiveStatusType.ACTIVE)
         postDto.isLikedByMe = postLikeRepository.existsByPostIdAndUserIdAndStatus(postDto.postId, userId, ActiveStatusType.ACTIVE)
 
         return postDto


### PR DESCRIPTION
댓글 수 불러올 때 삭제된 댓글까지 숫자에 포함시키는 오류가 있어서 댓글 불러오기 쿼리에 active_status 추가하여 수정하였음